### PR TITLE
API sample missing "errors" import

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ CookieMonster exposes `pkg/monster`, which allows other applications to easily t
 ```go
 import (
     "github.com/iangcarroll/cookiemonster/pkg/monster"
+    "errors"
 )
 
 var (


### PR DESCRIPTION
It seems like you forgot to include this import on the demo, pretty basic and totally not-important PR but wanted todo it anyways